### PR TITLE
fix(forummanage): a counter init typo.

### DIFF
--- a/forummanage.php
+++ b/forummanage.php
@@ -163,7 +163,7 @@ if ($_GET['action'] == "editforum") {
 $res = sql_query ("SELECT sort FROM forums");
 $nr = mysql_num_rows($res);
             $maxclass = $nr + 1;
-          for ($i = 0; $i <= $maxclass; ++$i)
+          for ($i = 1; $i <= $maxclass; ++$i)
             print("<option value=$i" . ($row["sort"] == $i ? " selected" : "") . ">$i \n");
 ?>
         </select>


### PR DESCRIPTION
Encountered SQL Error when change the order of sub forums.

> You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '0'', name = '站务讨论', description = '站务讨论', forid = 1, minclassrea' at line 1 in /var/www/html/forummanage.php, line 49

I think here's the point.